### PR TITLE
PREAPPS-9207 Transfer Synacor-managed preact-context-provider to Zimbra Org and Upgrade for Node.js Compatibility

### DIFF
--- a/src/components/insert-template/template-pane.js
+++ b/src/components/insert-template/template-pane.js
@@ -5,12 +5,15 @@ import cx from 'classnames';
 import { useState, useEffect } from 'preact/hooks';
 import { fetchListing } from '../../lib/util';
 import { callWith } from '@zimbra-client/util';
+import { useZimbraContext } from '@zimbra-client/hooks';
 import get from 'lodash-es/get';
 
-export default function TemplatePane(
-	{ selectedFolderName, selectedTemplate, setSelectedTemplate },
-	context
-) {
+export default function TemplatePane({
+	selectedFolderName,
+	selectedTemplate,
+	setSelectedTemplate
+}) {
+	const context = useZimbraContext();
 	const [templateList, setTemplateList] = useState([]);
 	const [clickedTemplate, setclickedTemplate] = useState(selectedTemplate);
 
@@ -51,7 +54,13 @@ export default function TemplatePane(
 		));
 	return (
 		<div class={style.innerClass}>
-			{templateList.length > 0 ? list : <div class={style.noItems}><Text id="emailTemplates.noTemplatesMsg" /></div>}
+			{templateList.length > 0 ? (
+				list
+			) : (
+				<div class={style.noItems}>
+					<Text id="emailTemplates.noTemplatesMsg" />
+				</div>
+			)}
 		</div>
 	);
 }

--- a/src/components/save-template/index.js
+++ b/src/components/save-template/index.js
@@ -10,20 +10,17 @@ import { useFoldersQuery } from '@zimbra-client/hooks/graphql';
 import withIntl from '../../enhancers';
 import get from 'lodash-es/get';
 
-function SaveTemplate(
-	{
-		getSubject,
-		subjectRequire,
-		getMessage,
-		closeSaveModal,
-		savedMsg,
-		saveMsgError,
-		saveMsgSelectFolder,
-		saveMsgPermissionIssue,
-		context: zimletContext
-	},
+function SaveTemplate({
+	getSubject,
+	subjectRequire,
+	getMessage,
+	closeSaveModal,
+	savedMsg,
+	saveMsgError,
+	saveMsgSelectFolder,
+	saveMsgPermissionIssue,
 	context
-) {
+}) {
 	const [state, setState] = useState(() => ({
 		folderList: [],
 		sharedFolders: [],
@@ -49,43 +46,42 @@ function SaveTemplate(
 					selectedFolderId: folderData.id
 				};
 			});
-		}, [selectedFolderId]
+		},
+		[selectedFolderId]
 	);
 
-	const handleSaveClick = useCallback(
-		() => {
-			const currSubject = getSubject();
-			if (currSubject.trim() == '') {
-				notify(subjectRequire);
-				return;
-			}
+	const handleSaveClick = useCallback(() => {
+		const currSubject = getSubject();
+		if (currSubject.trim() == '') {
+			notify(subjectRequire);
+			return;
+		}
 
-			const msg = getMessage();
-			if (selectedFolderId !== null) {
-				moveMessage(context, msg.draftId, selectedFolderId)
-					.then(moveRes => {
-						if (moveRes.id) {
-							notify(savedMsg);
-							closeSaveModal();
-						} else {
-							notify(saveMsgPermissionIssue);
-						}
-					})
-					.catch(error => {
-						notify(saveMsgError);
-						console.error('Error: ', error);
+		const msg = getMessage();
+		if (selectedFolderId !== null) {
+			moveMessage(context, msg.draftId, selectedFolderId)
+				.then(moveRes => {
+					if (moveRes.id) {
+						notify(savedMsg);
 						closeSaveModal();
-					});
-			} else {
-				notify(saveMsgSelectFolder);
-			}
-		}, [selectedFolderId]
-	);
+					} else {
+						notify(saveMsgPermissionIssue);
+					}
+				})
+				.catch(error => {
+					notify(saveMsgError);
+					console.error('Error: ', error);
+					closeSaveModal();
+				});
+		} else {
+			notify(saveMsgSelectFolder);
+		}
+	}, [selectedFolderId]);
 
 	const notify = message => {
-		const { dispatch } = zimletContext.store;
+		const { dispatch } = context.store;
 		dispatch(
-			zimletContext.zimletRedux.actions.notifications.notify({
+			context.zimletRedux.actions.notifications.notify({
 				message
 			})
 		);
@@ -93,13 +89,15 @@ function SaveTemplate(
 
 	useEffect(() => {
 		if (data) {
-			const folders = (get(data, 'getFolder.folders.0.folders') || []).filter(folder => !FILTER_FOLDER_IDS.includes(parseInt(folder.id))) // Trash, Chat
-			const sharedFolders = (get(data, 'getFolder.folders.0.linkedFolders') || []);
+			const folders = (get(data, 'getFolder.folders.0.folders') || []).filter(
+				folder => !FILTER_FOLDER_IDS.includes(parseInt(folder.id))
+			); // Trash, Chat
+			const sharedFolders = get(data, 'getFolder.folders.0.linkedFolders') || [];
 			setState(prevState => {
 				return {
 					...prevState,
 					folderList: folders,
-					sharedFolders: sharedFolders,
+					sharedFolders,
 					loading: false
 				};
 			});
@@ -122,26 +120,28 @@ function SaveTemplate(
 			{loading ? (
 				<Spinner block />
 			) : (
-					<div class={style.dataInner}>
-						<div class={style.leftSide}>
-							<p class={style.saveTip}>{saveMsgSelectFolder}</p>
-							<FolderListLight
-								folders={folderList}
-								folderNameProp={getFolderName}
-								onFolderClick={handleFolderClick}
-								sharedFolders={sharedFolders}
-							/>
-						</div>
+				<div class={style.dataInner}>
+					<div class={style.leftSide}>
+						<p class={style.saveTip}>{saveMsgSelectFolder}</p>
+						<FolderListLight
+							folders={folderList}
+							folderNameProp={getFolderName}
+							onFolderClick={handleFolderClick}
+							sharedFolders={sharedFolders}
+						/>
 					</div>
-				)}
+				</div>
+			)}
 		</ModalDialog>
 	);
 }
 
-export default withIntl()(withText({
-	subjectRequire: 'emailTemplates.subjectRequire',
-	savedMsg: 'emailTemplates.savedMsg',
-	saveMsgError: 'emailTemplates.saveMsgError',
-	saveMsgSelectFolder: 'emailTemplates.saveMsgSelectFolder',
-	saveMsgPermissionIssue: 'emailTemplates.saveMsgPermissionIssue'
-})(SaveTemplate));
+export default withIntl()(
+	withText({
+		subjectRequire: 'emailTemplates.subjectRequire',
+		savedMsg: 'emailTemplates.savedMsg',
+		saveMsgError: 'emailTemplates.saveMsgError',
+		saveMsgSelectFolder: 'emailTemplates.saveMsgSelectFolder',
+		saveMsgPermissionIssue: 'emailTemplates.saveMsgPermissionIssue'
+	})(SaveTemplate)
+);


### PR DESCRIPTION
This PR replaces the legacy preact-context-provider dependency with a native Modern Context API (createContext) implementation. This transition resolves architectural technical debt.
Changes:

1. Transition to Modern Context API

- Removed preact-context-provider.

- Introduced ZimbraProvider using native createContext to handle global state injection (e.g., hostName, dispatch, zimletRedux).

- Created a custom useZimbra hook for functional components to access context safely.

2. Custom Decorator Implementation

- Developed a custom getContext HOC/decorator to maintain backward compatibility for Class Components.

- The new getContext bridge uses the modern useZimbraContext hook under the hood, allowing legacy @getcontext usage to work with the new Provider without refactoring business logic.

3. Update all the usage